### PR TITLE
Store the correct filename in the annotations database

### DIFF
--- a/app.py
+++ b/app.py
@@ -178,7 +178,11 @@ def plot_spectrogram(signal, f_rate):
 
 @app.route("/annontate_page")
 def annontate_page():
-    random_file = random.choice(os.listdir("static/subsample_wavs"))
+    wavs_available = os.listdir("static/subsample_wavs")
+    if True: # only_show_unannotated
+        got_already = set([row.audio_name for row in Annontate.query.all()])
+        wavs_available = [awav for awav in wavs_available if awav not in got_already]
+    random_file = random.choice(wavs_available)
     read_audio(random_file)
     return render_template('annontate_page.html', url='/static/specto/new_plot.png', random_file=random_file)
 

--- a/app.py
+++ b/app.py
@@ -176,13 +176,17 @@ def plot_spectrogram(signal, f_rate):
 #    plot_spectrogram(y)
 
 
-@app.route("/annontate_page")
-def annontate_page():
+def get_random_file():
     wavs_available = os.listdir("static/subsample_wavs")
     if True: # only_show_unannotated
         got_already = set([row.audio_name for row in Annontate.query.all()])
         wavs_available = [awav for awav in wavs_available if awav not in got_already]
     random_file = random.choice(wavs_available)
+    return random_file
+
+@app.route("/annontate_page")
+def annontate_page():
+    random_file = get_random_file()
     read_audio(random_file)
     return render_template('annontate_page.html', url='/static/specto/new_plot.png', random_file=random_file)
 
@@ -195,44 +199,26 @@ def logout():
 
 @app.route("/anwser_yes")
 def anwser_yes():
-    random_file = random.choice(os.listdir(
-        "static/subsample_wavs"))
-    read_audio(random_file)
-    today = date.today()
-    new_date = today.strftime("%d/%m/%Y")
-    new_annontate = Annontate(
-        data='Yes', date=new_date, user_email=current_user.email, audio_name=random_file)
-    db.session.add(new_annontate)
-    db.session.commit()
-    return render_template('annontate_page.html', url='/static/specto/new_plot.png', random_file=random_file)
-
+    store_answer("Yes")
+    return annontate_page()
 
 @app.route("/anwser_no")
 def anwser_no():
-    random_file = random.choice(os.listdir(
-        "static/subsample_wavs"))
-    read_audio(random_file)
-    today = date.today()
-    new_date = today.strftime("%d/%m/%Y")
-    new_annontate = Annontate(
-        data='no', date=new_date, user_email=current_user.email, audio_name=random_file)
-    db.session.add(new_annontate)
-    db.session.commit()
-    return render_template('annontate_page.html', url='/static/specto/new_plot.png', random_file=random_file)
-
+    store_answer("no")
+    return annontate_page()
 
 @app.route("/anwser_maybe")
 def anwser_maybe():
-    random_file = random.choice(os.listdir(
-        "static/subsample_wavs"))
-    read_audio(random_file)
+    store_answer("maybe")
+    return annontate_page()
+
+def store_answer(the_answer):
     today = date.today()
     new_date = today.strftime("%d/%m/%Y")
     new_annontate = Annontate(
-        data='maybe', date=new_date, user_email=current_user.email, audio_name=random_file)
+        data=the_answer, date=new_date, user_email=current_user.email, audio_name=request.args.get("filename"))
     db.session.add(new_annontate)
     db.session.commit()
-    return render_template('annontate_page.html', url='/static/specto/new_plot.png', random_file=random_file)
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -134,7 +134,7 @@ def login_submit():
 
 def read_audio(random_file):
     raw = wave.open(
-        "/home/chinlee5/annon_app_v2/static/subsample_wavs/" + random_file, "r")
+        "static/subsample_wavs/" + random_file, "r")
     # Extract Raw Audio from Wav File
     signal = raw.readframes(-1)
     signal = np.frombuffer(signal, dtype="int16")
@@ -155,7 +155,7 @@ def plot_waveform(signal, f_rate):
     plt.title("Sound Wave")
     ax.set_xlabel("Time (s)")
     ax.plot(time, signal)
-    fig.savefig('/home/chinlee5/annon_app_v2/static/images/new_plot.png')
+    fig.savefig('static/images/new_plot.png')
 
 
 def plot_spectrogram(signal, f_rate):
@@ -167,7 +167,7 @@ def plot_spectrogram(signal, f_rate):
     fig, ax = plt.subplots()
     ax.set_xlabel("Time (s)")
     ax.specgram(signal, Fs=f_rate)
-    fig.savefig('/home/chinlee5/annon_app_v2/static/specto/new_plot.png')
+    fig.savefig('static/specto/new_plot.png')
 
 
 
@@ -178,7 +178,7 @@ def plot_spectrogram(signal, f_rate):
 
 @app.route("/annontate_page")
 def annontate_page():
-    random_file = random.choice(os.listdir("/home/chinlee5/annon_app_v2/static/subsample_wavs"))
+    random_file = random.choice(os.listdir("static/subsample_wavs"))
     read_audio(random_file)
     return render_template('annontate_page.html', url='/static/specto/new_plot.png', random_file=random_file)
 
@@ -192,7 +192,7 @@ def logout():
 @app.route("/anwser_yes")
 def anwser_yes():
     random_file = random.choice(os.listdir(
-        "/home/chinlee5/annon_app_v2/static/subsample_wavs"))
+        "static/subsample_wavs"))
     read_audio(random_file)
     today = date.today()
     new_date = today.strftime("%d/%m/%Y")
@@ -206,7 +206,7 @@ def anwser_yes():
 @app.route("/anwser_no")
 def anwser_no():
     random_file = random.choice(os.listdir(
-        "/home/chinlee5/annon_app_v2/static/subsample_wavs"))
+        "static/subsample_wavs"))
     read_audio(random_file)
     today = date.today()
     new_date = today.strftime("%d/%m/%Y")
@@ -220,7 +220,7 @@ def anwser_no():
 @app.route("/anwser_maybe")
 def anwser_maybe():
     random_file = random.choice(os.listdir(
-        "/home/chinlee5/annon_app_v2/static/subsample_wavs"))
+        "static/subsample_wavs"))
     read_audio(random_file)
     today = date.today()
     new_date = today.strftime("%d/%m/%Y")

--- a/templates/annontate_page.html
+++ b/templates/annontate_page.html
@@ -6,14 +6,14 @@
     <img src="{{url}}" alt="Wave" height="30%" width="60%">
     {% if random_file %}
     <div>
-        <audio controls>
+        <audio controls autoplay="yes">
             <source src="{{ url_for('static', filename='/subsample_wavs/'+ random_file) }}">
         </audio>
     </div>
     <div class="buttons">
-        <a class="btn btn-success" id="yes" href="{{url_for('anwser_yes')}}">Yes</a>
-        <a class="btn btn-danger" id="no" href="{{url_for('anwser_no')}}">No</a>
-        <a class="btn btn-dark" id="maybe" href="{{url_for('anwser_maybe')}}">Not sure</a>
+        <a class="btn btn-success" id="yes" href="{{url_for('anwser_yes')}}" accesskey="a">Yes</a>
+        <a class="btn btn-danger" id="no" href="{{url_for('anwser_no')}}" accesskey="z">No</a>
+        <a class="btn btn-dark" id="maybe" href="{{url_for('anwser_maybe')}}" accesskey="x">Not sure</a>
     </div>
     {% endif %}
 </div>

--- a/templates/annontate_page.html
+++ b/templates/annontate_page.html
@@ -11,9 +11,9 @@
         </audio>
     </div>
     <div class="buttons">
-        <a class="btn btn-success" id="yes" href="{{url_for('anwser_yes')}}" accesskey="a">Yes</a>
-        <a class="btn btn-danger" id="no" href="{{url_for('anwser_no')}}" accesskey="z">No</a>
-        <a class="btn btn-dark" id="maybe" href="{{url_for('anwser_maybe')}}" accesskey="x">Not sure</a>
+	    <a class="btn btn-success" id="yes"  href="{{url_for('anwser_yes')}}?filename={{random_file}}" accesskey="a">Yes</a>
+	    <a class="btn btn-danger" id="no"     href="{{url_for('anwser_no')}}?filename={{random_file}}" accesskey="z">No</a>
+	    <a class="btn btn-dark" id="maybe" href="{{url_for('anwser_maybe')}}?filename={{random_file}}" accesskey="x">Not sure</a>
     </div>
     {% endif %}
 </div>


### PR DESCRIPTION
This branch includes some cleanups and minor interface tweaks, plus an important bugfix. Previously, the correct filename was not stored in the annotations database. Instead, a new random one was stored, that the user did not know about! To fix that, we need to "remember" the filename by including it in the webform as a parameter and then storing that in the return call.